### PR TITLE
Remove the no longer existing natives.bin in the discord package

### DIFF
--- a/community/discord/build
+++ b/community/discord/build
@@ -13,7 +13,6 @@ cp -r Discord \
     libGLESv2.so \
     libffmpeg.so \
     locales \
-    natives_blob.bin \
     resources \
     resources.pak \
     snapshot_blob.bin \


### PR DESCRIPTION
This fixes the following output:
```
~ $ kiss b discord
-> Resolving dependencies
-> Building: discord
-> discord Checking repository files
-> Checking for pre-built dependencies
-> discord Downloading sources
-> discord Downloading https://discord.com/api/download?platform=linux&format=tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   337  100   337    0     0   2246      0 --:--:-- --:--:-- --:--:--  2246
100 67.6M  100 67.6M    0     0  9030k      0  0:00:07  0:00:07 --:--:--  9.9M
-> Verified all checksums
-> discord Building package (1/1)
-> discord Extracting sources
-> discord Starting build
cp: can't stat 'natives_blob.bin': No such file or directory
-> discord Build failed
-> discord Log stored to /home/david/.cache/kiss/logs//discord-2020-12-12-23:18-26729
Terminated
```